### PR TITLE
Updated grammar reference based on changes in language-chef package

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -62,7 +62,8 @@ lint = (editor) ->
 linter =
   name: 'cookstyle'
   grammarScopes: [
-    'source.ruby.chef'
+    'source.chef.metadata',
+    'source.chef.recipes'
   ]
   scope: 'file'
   lintsOnChange: true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linter-cookstyle",
   "main": "./lib/index.coffee",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Lint Chef code on the fly, using cookstyle",
   "engines": {
     "atom": "*"
@@ -13,7 +13,7 @@
   },
   "package-deps": [
     "linter:2.0.0",
-    "language-chef"
+    "language-chef:2.0.1"
   ],
   "providedServices": {
     "linter": {


### PR DESCRIPTION
The names for grammar scopes change in language-chef at version 2.0.1.  This PR updates the grammarScopes to the new names and sets a version dependency at language-chef:2.0.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mattstratton/linter-cookstyle/14)
<!-- Reviewable:end -->
